### PR TITLE
Fix package naming and improve configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,30 @@
-# Gemini API�L�[ (�K�{)
+# Gemini APIキー (必須)
 GEMINI_API_KEY="YOUR_GEMINI_API_KEY_HERE"
 
-# Gemini ���f�� (�C�ӁA�f�t�H���g�� gemini-2.5-flash-preview-04-17)
-# ���ݐ��������ŐV���f���̈�ł��B�K�v�ɉ����đ��̃��f�����w�肵�Ă��������B
-# ��: GEMINI_MODEL="gemini-pro"
+# Gemini モデル (任意、デフォルトは gemini-2.5-flash-preview-04-17)
+# 現在利用可能な最新モデルの一つです。必要に応じて別のモデルを指定してください。
+# 例: GEMINI_MODEL="gemini-pro"
 GEMINI_MODEL="gemini-2.5-flash-preview-04-17"
 
-# �|��v�����v�g (�C�ӁA���ݒ�܂��͋�̏ꍇ�̓X�N���v�g���̃f�t�H���g�v�����v�g���g�p)
-# ���̃v�����v�g�́ALLM�Ƀe�L�X�g�̖|����@���w�����邽�߂Ɏg�p����܂��B
-# �X�N���v�g�� ${language}�A${uniqueSeparator}�A${textsToTranslate} �����ۂ̒l�ɒu�������܂��B
-# �����ύX����ꍇ�A�����̃v���[�X�z���_�[���������g�p����Ă��邱�Ƃ��m�F���Ă��������B
-TRANSLATION_PROMPT=`���Ȃ��͍��x�Ȗ|��API�ł��B�ȉ��̕����̉p��̃e�L�X�g���A���ꂼ�ꒉ���� ${language} �ɖ|�󂵂Ă��������B
-�e�p��e�L�X�g�́uITEM_START [�ԍ�]�v�Ŏn�܂�uITEM_END�v�ŏI���܂��B�����āA�e�p��e�L�X�g�Ԃ́u${uniqueSeparator}�v�Ƃ�������ȕ�����ŋ�؂��Ă��܂��B
+# 翻訳プロンプト (任意、現在設定値または空の場合はスクリプト内のデフォルトプロンプトを使用)
+# このプロンプトは、LLMにテキストの翻訳方法を指示するために使用されます。
+# スクリプトは ${language}、${uniqueSeparator}、${textsToTranslate} を実際の値に置換します。
+# これを変更する場合、必ずこれらのプレースホルダーが正しく使用されていることを確認してください。
+TRANSLATION_PROMPT=`あなたは高精度な翻訳APIです。以下の複数の英語のテキストを、それぞれ丁寧に ${language} に翻訳してください。
+各項目テキストは「ITEM_START [番号]」で始まり「ITEM_END」で終わります。そして、各項目テキスト間は「${uniqueSeparator}」という固有な区切り文字で区切られています。
 
-���Ȃ��̃^�X�N�́A�e�p��e�L�X�g�� ${language} �ɖ|�󂵁A�|�󌋉ʂ݂̂�Ԃ����Ƃł��B
-�|�󌋉ʂ��A�K�������̏��Ԓʂ�ɁA�u${uniqueSeparator}�v�Ƃ����S������������ŋ�؂��ĕԂ��Ă��������B
-�uITEM_START [�ԍ�]�v��uITEM_END�v�Ƃ������}�[�J�[�͖|�󌋉ʂɊ܂߂Ȃ��ł��������B
-���A�A�����A�O�u���A�㏑���A���̑��̒ǉ����͈�؊܂߂��A�|�󂳂ꂽ�e�L�X�g�Q�������u${uniqueSeparator}�v�ŋ�؂��ďo�͂��Ă��������B
+あなたのタスクは、各項目テキストを ${language} に翻訳し、翻訳結果のみを返すことです。
+翻訳結果を、必ず同じ順番通りに、「${uniqueSeparator}」という完全に一致する区切り文字で区切って返してください。
+「ITEM_START [番号]」や「ITEM_END」というマーカーは翻訳結果に含めないでください。
+また、あいさつ、前書き、補書き、その他の追加説明は一切含めず、翻訳されたテキスト群を「${uniqueSeparator}」で区切って出力してください。
 
-�p��e�L�X�g�Q:
-${textsToTranslate}
+英語テキスト群:
+\${textsToTranslate}
 
-${language}�ւ̖|�󌋉ʌQ (�e�|����u${uniqueSeparator}�v�ŋ�؂��Ă�������):`
+\${language}への翻訳結果群 (各翻訳を「\${uniqueSeparator}」で区切ってください):`
 
-# �|��Ώی��� (�C�ӁA���ݒ�̏ꍇ�͓��{��݂̂�ΏۂƂ��܂�)
-# JSON�`���̕�����ŁA�I�u�W�F�N�g�̔z��Ƃ��Ďw�肵�܂��B
-# �e�I�u�W�F�N�g�� "name" (����R�[�h�A��: "en", "ko") �� "label" (���ꖼ�A��: "English", "�؍���") �����K�v������܂��B
-# ��: TARGET_LANGUAGES='[{"name":"ja","label":"���{��"},{"name":"en","label":"English"}]'
-TARGET_LANGUAGES='[{"name":"ja","label":"���{��"}]'
+# 翻訳対象言語 (任意、現在設定の場合は日本語のみを対象とします)
+# JSON形式の文字列で、オブジェクトの配列として指定します。
+# 各オブジェクトに "name" (言語コード、例: "en", "ko") と "label" (言語名、例: "English", "한국어") が必要になります。
+# 例: TARGET_LANGUAGES='[{"name":"ja","label":"日本語"},{"name":"en","label":"English"}]'
+TARGET_LANGUAGES='[{"name":"ja","label":"日本語"}]'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: editor-ui 言語ファイルのパッケージ化
 
 on:
   schedule:
-  - cron: "0 * * * *"
+  - cron: "0 6 * * *"
   workflow_dispatch:
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "n8n-i18n-chinese",
+  "name": "n8n-i18n-japanese",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/other-blowsnow/n8n-i18n-chinese.git"
+    "url": "https://github.com/nemumusito/n8n-i18n-japanese.git"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Fix inconsistent package naming from Chinese to Japanese
- Resolve character encoding issues in .env.example
- Optimize GitHub Actions frequency to prevent API rate limits

## Changes Made
- **package.json**: Updated name from "n8n-i18n-chinese" to "n8n-i18n-japanese" and corrected repository URL
- **.env.example**: Fixed corrupted Japanese characters due to encoding issues  
- **GitHub Actions**: Reduced workflow schedule from hourly to daily to avoid API rate limits

## Test plan
- [ ] Verify package.json changes are correctly reflected
- [ ] Confirm .env.example file displays Japanese characters properly
- [ ] Check GitHub Actions runs on new schedule without rate limit issues

🤖 Generated with [Claude Code](https://claude.ai/code)